### PR TITLE
Adds support for transactions with no notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ services:
 #      - OPENAI_MODEL= # optional. required if you want to use a specific model, default is "gpt-3.5-turbo-instruct"
 #      - OPENAI_BASE_URL= # optional. required if you don't want to use the OpenAI API but OpenAI compatible API
 #      - ACTUAL_E2E_PASSWORD= # optional. required if you have E2E encryption
+#      - NODE_TLS_REJECT_UNAUTHORIZED=0 # optional. required if you have trouble connecting to Actual server 
 ```
 
 ### 📝 Notes from the author

--- a/src/actual-api.js
+++ b/src/actual-api.js
@@ -11,15 +11,20 @@ async function initializeApi() {
     fs.mkdirSync(dataDir);
   }
   await actualApi.init({ dataDir, serverURL, password });
-  if (e2ePassword) {
-    await actualApi.downloadBudget(budgetId, {
-      password: e2ePassword,
-    });
-  } else {
-    await actualApi.downloadBudget(budgetId);
+  try {
+    if (e2ePassword) {
+      await actualApi.downloadBudget(budgetId, {
+        password: e2ePassword,
+      });
+    } else {
+      await actualApi.downloadBudget(budgetId);
+    }
+    console.log('Budget downloaded');
+  } catch (error) {
+    console.error('Failed to download budget:', error.message);
+    throw new Error('Budget download failed');
   }
 }
-
 async function shutdownApi() {
   await actualApi.shutdown();
 }

--- a/src/openai.js
+++ b/src/openai.js
@@ -4,7 +4,7 @@ const { model } = require('./config');
 const openai = new OpenAI({});
 
 function generatePrompt(categoryGroups, transaction, payees) {
-  let prompt = 'Given I want to categorize the bank transactions in following categories:\n';
+  let prompt = 'I want to categorize the given bank transactions into the following categories:\n';
   categoryGroups.forEach((categoryGroup) => {
     categoryGroup.categories.forEach((category) => {
       prompt += `* ${category.name} (${categoryGroup.name}) (ID: "${category.id}") \n`;
@@ -24,7 +24,7 @@ function generatePrompt(categoryGroups, transaction, payees) {
     prompt += `* Payee: ${transaction.imported_payee}\n`;
   }
 
-  prompt += 'ANSWER BY A CATEGORY ID.DO NOT WRITE THE WHOLE SENTENCE. Do not guess, if you don\'t know answer: "idk".';
+  prompt += 'ANSWER BY A CATEGORY ID. DO NOT WRITE THE WHOLE SENTENCE. Do not guess, if you don\'t know the answer, return "idk".';
 
   return prompt;
 }

--- a/src/transaction-service.js
+++ b/src/transaction-service.js
@@ -35,7 +35,7 @@ async function processTransactions() {
     (transaction) => !transaction.category
           && transaction.transfer_id === null
           && transaction.starting_balance_flag !== true
-          && transaction.notes.includes(NOTES_NOT_GUESSED) === false,
+          && (transaction.notes === null || transaction.notes.includes(NOTES_NOT_GUESSED) === false),
   );
 
   for (let i = 0; i < uncategorizedTransactions.length; i++) {

--- a/src/transaction-service.js
+++ b/src/transaction-service.js
@@ -35,7 +35,8 @@ async function processTransactions() {
     (transaction) => !transaction.category
           && transaction.transfer_id === null
           && transaction.starting_balance_flag !== true
-          && (transaction.notes === null || transaction.notes.includes(NOTES_NOT_GUESSED) === false),
+          && (transaction.notes === null
+              || transaction.notes.includes(NOTES_NOT_GUESSED) === false),
   );
 
   for (let i = 0; i < uncategorizedTransactions.length; i++) {


### PR DESCRIPTION
I was using Actual manualy, so some transactions don't have notes or payees.
I now sync bank accounts, but the older transactions were blocking the actual-ai process.
This PR allows actual-ai to add the transactions without notes to the uncategorizedTransactions array.

I also added various quick fixes:
 - try/catch block on downloadBudget
 - Typos in the AI Prompt
 - NODE_TLS_REJECT_UNAUTHORIZED=0 to README
 
Thank you!