### PR TITLE
FEATURE: oneshot container

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -2,14 +2,16 @@ import cron from 'node-cron';
 import { cronSchedule, isFeatureEnabled } from './src/config';
 import actualAi from './src/container';
 
-if (!cron.validate(cronSchedule)) {
-  console.error('Invalid cron schedule:', cronSchedule);
+if (!isFeatureEnabled('classifyOnStartup') && !cron.validate(cronSchedule)) {
+  console.error('classifyOnStartup not set or invalid cron schedule:', cronSchedule);
   process.exit(1);
 }
 
-cron.schedule(cronSchedule, async () => {
-  await actualAi.classify();
-});
+if (cron.validate(cronSchedule)) {
+  cron.schedule(cronSchedule, async () => {
+    await actualAi.classify();
+  });
+}
 
 console.log('Application started');
 if (isFeatureEnabled('classifyOnStartup')) {


### PR DESCRIPTION
This add a feature to run categorization once:

if `classifyOnStartup` is set but no (or invalid) cron schedule, the actions run once after which the container dies.