### PR TITLE
fix: include 'set to no category' rules in LLM prompt context

### DIFF
--- a/src/utils/rule-utils.ts
+++ b/src/utils/rule-utils.ts
@@ -10,50 +10,54 @@ export function transformRulesToDescriptions(
   categories: (APICategoryEntity | APICategoryGroupEntity)[],
   payees: APIPayeeEntity[] = [],
 ): RuleDescription[] {
-  return rules.map((rule) => {
-    const categoryAction = rule.actions.find(
+  // Improved payee resolution with clean JSON structure
+  const resolvePayeeValue = (value: string | string[]) => {
+    const resolveSingle = (id: string) => payees.find((p) => p.id === id)?.name ?? id;
+
+    return Array.isArray(value)
+      ? value.map(resolveSingle)
+      : resolveSingle(value);
+  };
+
+  return rules
+    .filter((rule) => rule.actions.some(
       (action) => 'field' in action && action.field === 'category' && action.op === 'set',
-    );
-    const categoryId = categoryAction?.value as string | undefined;
-    const category = categories.find((c) => 'id' in c && c.id === categoryId);
+    ))
+    .map((rule) => {
+      const categoryAction = rule.actions.find(
+        (action) => 'field' in action && action.field === 'category' && action.op === 'set',
+      );
+      const categoryId = categoryAction?.value as string | undefined;
+      const category = categories.find((c) => 'id' in c && c.id === categoryId);
 
-    // Improved payee resolution with clean JSON structure
-    const resolvePayeeValue = (value: string | string[]) => {
-      const resolveSingle = (id: string) => payees.find((p) => p.id === id)?.name ?? id;
+      return {
+        conditions: rule.conditions.map((c) => {
+          // Structure condition as properly typed object
+          const condition: {
+            field: string;
+            op: string;
+            type?: string;
+            value: string | string[];
+          } = {
+            field: c.field,
+            op: c.op,
+            type: c.type,
+            value: '', // Default value, will be updated below
+          };
 
-      return Array.isArray(value)
-        ? value.map(resolveSingle)
-        : resolveSingle(value);
-    };
+          if (c.field === 'payee' && c.type === 'id') {
+            condition.value = resolvePayeeValue(c.value);
+          } else {
+            condition.value = typeof c.value === 'object' ? (c.value as string[]) : String(c.value);
+          }
 
-    return {
-      conditions: rule.conditions.map((c) => {
-        // Structure condition as properly typed object
-        const condition: {
-          field: string;
-          op: string;
-          type?: string;
-          value: string | string[];
-        } = {
-          field: c.field,
-          op: c.op,
-          type: c.type,
-          value: '', // Default value, will be updated below
-        };
-
-        if (c.field === 'payee' && c.type === 'id') {
-          condition.value = resolvePayeeValue(c.value);
-        } else {
-          condition.value = typeof c.value === 'object' ? (c.value as string[]) : String(c.value);
-        }
-
-        return condition;
-      }),
-      categoryName: category && 'name' in category ? category.name : 'unknown',
-      categoryId: categoryId ?? '',
-      ruleName: 'name' in rule ? rule.name as string : 'Unnamed rule',
-    };
-  }).filter((r) => r.categoryId);
+          return condition;
+        }),
+        categoryName: category && 'name' in category ? category.name : (categoryId ? 'unknown' : 'leave uncategorized'),
+        categoryId: categoryId ?? '',
+        ruleName: 'name' in rule ? rule.name as string : 'Unnamed rule',
+      };
+    });
 }
 
 export default { transformRulesToDescriptions };


### PR DESCRIPTION
## Problem

Rules that explicitly set a transaction's category to **nothing** (null) are silently dropped before the LLM prompt is built. In `transformRulesToDescriptions`, after the `.map()` the results are filtered with:

```ts
.filter((r) => r.categoryId)
```

A rule like *"if payee is Amazon → set category to nothing"* produces `categoryId: ''`, which is falsy, so it is excluded. The LLM has no visibility into these intentional "leave uncategorized" rules and treats the affected transactions as unknown — classifying them anyway, defeating the purpose of the rule.

## Fix

Two changes in `src/utils/rule-utils.ts`:

1. **Pre-filter** to only rules that have a `category: set` action (replacing the post-filter). This correctly excludes unrelated rules (e.g. payee-rename) without also discarding "set to nothing" rules.

2. **Descriptive label** — when a rule sets category to null/empty, render it as `→ leave uncategorized` in the prompt instead of `→ unknown`, so the LLM understands the intent.

## Result

The LLM now sees rules like:
```
5. Amazon → leave uncategorized
   Conditions: payee is Amazon
```

…and correctly leaves those transactions for manual review instead of guessing a category.

## Testing

Verified by inspecting the rendered prompt for a budget with a "payee is Amazon → set category to nothing" rule. Before this fix the rule was absent from the prompt; after it appears with `→ leave uncategorized`.