### PR TITLE
Fix category optimizer: stem plurals, pre-resolve groups before parallel create

### DIFF
--- a/src/similarity-calculator.ts
+++ b/src/similarity-calculator.ts
@@ -1,3 +1,30 @@
+const STOP_WORDS = new Set([
+  '', 'and', 'or', 'the', 'of', 'a', 'an', 'to', 'for', 'in', 'on',
+]);
+
+function stemWord(word: string): string {
+  if (word.length <= 3) return word;
+  if (word.endsWith('ies') && word.length > 4) return `${word.slice(0, -3)}y`;
+  if (word.endsWith('sses')) return word.slice(0, -2);
+  if (
+    word.endsWith('xes')
+    || word.endsWith('zes')
+    || word.endsWith('ches')
+    || word.endsWith('shes')
+  ) return word.slice(0, -2);
+  if (word.endsWith('s') && !word.endsWith('ss')) return word.slice(0, -1);
+  return word;
+}
+
+function tokenize(normalized: string): Set<string> {
+  return new Set(
+    normalized
+      .split(' ')
+      .map(stemWord)
+      .filter((w) => !STOP_WORDS.has(w)),
+  );
+}
+
 class SimilarityCalculator {
   public calculateNameSimilarity(name1: string, name2: string): number {
     // Normalize the strings for comparison
@@ -6,16 +33,25 @@ class SimilarityCalculator {
 
     if (a === b) return 1.0;
 
-    // Check for exact word matches
-    const words1 = new Set(a.split(' '));
-    const words2 = new Set(b.split(' '));
+    // Build word sets after stemming + stopword removal so plurals
+    // ("sport"/"sports") and connectors ("&", "and") don't create
+    // spurious mismatches.
+    const words1 = tokenize(a);
+    const words2 = tokenize(b);
 
     // Calculate Jaccard similarity for words
     const intersection = new Set([...words1].filter((x) => words2.has(x)));
     const union = new Set([...words1, ...words2]);
 
-    // Weight for word overlap
-    const wordSimilarity = intersection.size / union.size;
+    const wordSimilarity = union.size === 0 ? 0 : intersection.size / union.size;
+
+    // Subset boost: when one name's content words are fully contained in
+    // the other's, the shorter name is likely a coarser version of the
+    // same concept ("Travel" vs "Travel Transport"). Nudge the score so
+    // these cluster together instead of bloating the category list.
+    const smallerSize = Math.min(words1.size, words2.size);
+    const isSubset = smallerSize > 0 && intersection.size === smallerSize;
+    const subsetBoost = isSubset ? 0.15 : 0;
 
     // Jaro-Winkler for character-level similarity
     const jaro = (s1: string, s2: string) => {
@@ -55,8 +91,8 @@ class SimilarityCalculator {
 
     const charSimilarity = jaro(a, b);
 
-    // Combine word-level and character-level similarity
-    return 0.6 * wordSimilarity + 0.4 * charSimilarity;
+    // Combine word-level and character-level similarity, capped at 1.0
+    return Math.min(1.0, 0.6 * wordSimilarity + 0.4 * charSimilarity + subsetBoost);
   }
 }
 

--- a/src/transaction/category-suggester.ts
+++ b/src/transaction/category-suggester.ts
@@ -38,27 +38,37 @@ class CategorySuggester {
 
     console.log(`Creating ${optimizedCategories.size} optimized categories`);
 
+    // Resolve unique group names to IDs sequentially BEFORE the parallel
+    // category creation. The LLM-provided `groupIsNew` flag cannot be
+    // trusted (it sometimes claims existing groups are new), and creating
+    // groups in parallel races on the Actual Budget API which throws
+    // "category group already exists" when two creations collide.
+    const uniqueGroupNames = Array.from(new Set(
+      Array.from(optimizedCategories.values()).map((s) => s.groupName),
+    ));
+    const groupIdByName = new Map<string, string>();
+    for (const groupName of uniqueGroupNames) {
+      const existing = categoryGroups.find(
+        (g) => g.name.toLowerCase() === groupName.toLowerCase(),
+      );
+      if (existing) {
+        groupIdByName.set(groupName, existing.id);
+        continue;
+      }
+      try {
+        const newId = await this.actualApiService.createCategoryGroup(groupName);
+        groupIdByName.set(groupName, newId);
+        console.log(`Created new category group "${groupName}" with ID ${newId}`);
+      } catch (error) {
+        console.error(`Error creating category group ${groupName}:`, error);
+      }
+    }
+
     // Use optimized categories instead of original suggestions
     await Promise.all(
       Array.from(optimizedCategories.entries()).map(async ([_key, suggestion]) => {
         try {
-          // First, ensure we have a group ID
-          let groupId: string;
-          if (suggestion.groupIsNew) {
-            groupId = await this.actualApiService.createCategoryGroup(suggestion.groupName);
-            console.log(`Created new category group "${suggestion.groupName}" with ID ${groupId}`);
-          } else {
-            // Find existing group with matching name
-            const existingGroup = categoryGroups.find(
-              (g) => g.name.toLowerCase() === suggestion.groupName.toLowerCase(),
-            );
-            groupId = existingGroup?.id
-                              ?? await this.actualApiService.createCategoryGroup(
-                                suggestion.groupName,
-                              );
-          }
-
-          // Validate groupId exists before creating category
+          const groupId = groupIdByName.get(suggestion.groupName);
           if (!groupId) {
             throw new Error(`Missing groupId for category ${suggestion.name}`);
           }

--- a/tests/similarity-calculator.test.ts
+++ b/tests/similarity-calculator.test.ts
@@ -57,5 +57,35 @@ describe('SimilarityCalculator', () => {
       const result = calculator.calculateNameSimilarity('Something', '');
       expect(result).toBeLessThan(0.2);
     });
+
+    it('should treat singular and plural forms as the same word', () => {
+      const result = calculator.calculateNameSimilarity('Sport & Fitness', 'Sports & Fitness');
+      expect(result).toBeGreaterThan(0.9);
+    });
+
+    it('should merge near-identical names that differ only by plural suffix', () => {
+      const result = calculator.calculateNameSimilarity('Subscription', 'Subscriptions');
+      expect(result).toBeGreaterThan(0.85);
+    });
+
+    it('should handle -ies plural form', () => {
+      const result = calculator.calculateNameSimilarity('Categories', 'Category');
+      expect(result).toBeGreaterThan(0.85);
+    });
+
+    it('should give high similarity when one name is a subset of the other', () => {
+      const result = calculator.calculateNameSimilarity('Travel', 'Travel & Transport');
+      expect(result).toBeGreaterThan(0.75);
+    });
+
+    it('should not over-merge unrelated names that share a stopword', () => {
+      const result = calculator.calculateNameSimilarity('The Coffee', 'The Hardware');
+      expect(result).toBeLessThan(0.55);
+    });
+
+    it('should keep distinct compound categories distinct', () => {
+      const result = calculator.calculateNameSimilarity('Health & Fitness', 'Health & Wellness');
+      expect(result).toBeLessThan(0.7);
+    });
   });
 });


### PR DESCRIPTION
Two bugs visible in production logs from a real run:

```
Optimized from 45 to 39 categories
Created new category "Sport & Fitness"
Created new category "Sports & Fitness"
Created new category "Sports & Leisure"
Created new category "Health & Fitness"
Created new category "Health & Wellness"
Error creating category Travel & Flights: Error: A 'Usual Expenses' category group already exists.
Error creating category Accommodation: Error: A 'Travel' category group already exists.
Error creating category Accommodation & Hotels: Error: A 'Travel' category group already exists.
```

## 1. Optimizer leaves near-duplicate categories unmerged

`SimilarityCalculator` builds Jaccard word-overlap on the raw split tokens, so `sport` / `sports` and `category` / `categories` count as different words. Combined with the dynamic threshold (~0.72), pairs that should obviously cluster — `Sport & Fitness` vs `Sports & Fitness`, `Subscriptions & Software` vs `Software & Tech Services` — drop below threshold and stay separate.

**Fix:** stem simple English plurals (`s`, `es`, `ies`, `sses`, `xes/zes/ches/shes`) and drop stopwords (`and`, `of`, `the`, …) before computing Jaccard. Add a small subset boost (+0.15) so coarser names like `Travel` cluster with `Travel & Transport` rather than each becoming its own category.

## 2. `groupIsNew` is unreliable and parallel group creation races

`CategorySuggester` trusts the LLM-supplied `groupIsNew` flag and calls `createCategoryGroup` whenever it's true. The LLM does hallucinate `groupIsNew: true` for groups that already exist (`Usual Expenses`, `Travel`), and `optimizeCategorySuggestions` propagates the flag with `cluster.some(s => s.groupIsNew)`, making the issue worse. On top of that, `Promise.all` runs the per-category creations in parallel — when two iterations independently see no existing group and both call `createCategoryGroup`, one loses with `A '<name>' category group already exists` and the entire category is dropped (`Travel & Flights`, `Accommodation`, `Accommodation & Hotels` in the log above).

**Fix:** stop trusting `groupIsNew`. Collect all unique group names from the optimized suggestions, resolve each one sequentially up front (existing match by case-insensitive name, otherwise create), and store the result in a `groupName -> groupId` map. The parallel category-creation loop then reads from that map, which removes the trust-the-flag problem and the race in one go.

## Tests

`npm test` — 8 suites, 71 tests passing, including 6 new cases for plural stemming, subset boost, stopword handling, and distinct-compound preservation:

- `Sport & Fitness` vs `Sports & Fitness` — > 0.9 (was ~0.58)
- `Subscription` vs `Subscriptions` — > 0.85
- `Categories` vs `Category` — > 0.85
- `Travel` vs `Travel & Transport` — > 0.75
- `The Coffee` vs `The Hardware` — < 0.55 (no over-merge from shared stopword)
- `Health & Fitness` vs `Health & Wellness` — < 0.7 (distinct compounds preserved)

The existing `Amazon` vs `Amazon.com` test (`> 0.6`) still passes; it now scores higher (~0.80) due to the subset boost.

## Out of scope

- Greedy single-pass clustering is order-dependent (cluster anchor = first member, not centroid). Three-way clusters like `[Travel, Travel & Transport, Travel & Leisure]` only fully merge when `Travel` appears first. Separate concern.
- `Transport` / `Transportation` doesn't merge — would need a Porter stemmer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)