### PR TITLE
fix(tags): stop clearPreviousTags from growing '-miss' chains on rerun

### DIFF
--- a/src/transaction/tag-service.ts
+++ b/src/transaction/tag-service.ts
@@ -28,14 +28,19 @@ class TagService {
   }
 
   public clearPreviousTags(notes: string): string {
+    // The "-miss" repair must run while the " #actual-ai" anchor still exists,
+    // and the longer tag must be cleared before the shorter one: the default
+    // guessedTag "#actual-ai" is a prefix of notGuessedTag "#actual-ai-miss",
+    // so clearing it first ate the tag's head and glued one stray "-miss" onto
+    // the note body per rerun ("…-miss-miss #actual-ai-miss").
     return notes
-      .replace(new RegExp(`\\s*${this.guessedTag}`, 'g'), '')
+      .replace(/(-miss)+(?= #actual-ai)/g, '')
       .replace(new RegExp(`\\s*${this.notGuessedTag}`, 'g'), '')
+      .replace(new RegExp(`\\s*${this.guessedTag}`, 'g'), '')
       .replace(new RegExp(`\\s*\\|\\s*${LEGACY_NOTES_NOT_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*\\|\\s*${LEGACY_NOTES_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*${LEGACY_NOTES_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*${LEGACY_NOTES_NOT_GUESSED}`, 'g'), '')
-      .replace(/-miss(?= #actual-ai)/g, '')
       .trim();
   }
 

--- a/tests/tag-service.test.ts
+++ b/tests/tag-service.test.ts
@@ -1,0 +1,44 @@
+import TagService from '../src/transaction/tag-service';
+
+describe('TagService', () => {
+  const service = new TagService('#actual-ai-miss', '#actual-ai');
+
+  describe('addNotGuessedTag', () => {
+    it('tags an untagged note', () => {
+      expect(service.addNotGuessedTag('some note')).toBe('some note #actual-ai-miss');
+    });
+
+    it('is idempotent on an already-tagged note (regression: "-miss" grew per rerun)', () => {
+      const once = service.addNotGuessedTag('some note');
+      expect(service.addNotGuessedTag(once)).toBe(once);
+    });
+
+    it('heals "-miss" chains left by the prefix-eating bug', () => {
+      expect(service.addNotGuessedTag('some note-miss-miss #actual-ai-miss'))
+        .toBe('some note #actual-ai-miss');
+    });
+  });
+
+  describe('addGuessedTag', () => {
+    it('replaces the miss tag without leaving a stray "-miss" on the note body', () => {
+      expect(service.addGuessedTag('some note #actual-ai-miss')).toBe('some note #actual-ai');
+    });
+
+    it('is idempotent on an already-guessed note', () => {
+      const once = service.addGuessedTag('some note');
+      expect(service.addGuessedTag(once)).toBe(once);
+    });
+  });
+
+  describe('clearPreviousTags', () => {
+    it('removes both tags and healed "-miss" chains', () => {
+      expect(service.clearPreviousTags('some note-miss #actual-ai-miss')).toBe('some note');
+      expect(service.clearPreviousTags('some note #actual-ai')).toBe('some note');
+    });
+
+    it('keeps unrelated note content untouched', () => {
+      const note = '[enrich:gocardless] eBay O*05-13940-83058 (Σ -42.73 EUR)';
+      expect(service.clearPreviousTags(`${note} #actual-ai-miss`)).toBe(note);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The default `guessedTag` `#actual-ai` is a prefix of the default `notGuessedTag` `#actual-ai-miss`. `clearPreviousTags` removes the guessed tag first:

```ts
.replace(new RegExp(`\\s*${this.guessedTag}`, 'g'), '')
```

On a note carrying ` #actual-ai-miss`, this eats the head of the miss tag and leaves `-miss` glued to the note body. The existing single-`-miss` repair regex runs *after* tag removal, when its ` #actual-ai` anchor is already gone, so it never matches. Every rerun over missed transactions (e.g. with `rerunMissedTransactions`) appends one more stray `-miss`:

```
some note #actual-ai-miss
→ some note-miss #actual-ai-miss
→ some note-miss-miss #actual-ai-miss
```

Observed on a live budget: every transaction that went through repeated miss-reruns had grown such chains.

## Fix

- Run the (now chain-aware) `-miss` repair first, while the ` #actual-ai` anchor still exists: `(-miss)+(?= #actual-ai)`.
- Clear the longer `notGuessedTag` before the shorter `guessedTag`.

Polluted notes self-heal on the next write: after deploying this fix, a rerun left 0 notes with `-miss-miss` (previously widespread).

## Tests

New `tests/tag-service.test.ts` — tagging, clearing, prefix safety, chain healing (7 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
