### PR TITLE
Pull in two upstream fixes: tag-chain corruption and prose JSON recovery

### DIFF
--- a/.github/workflows/dockerhub-update-description.yml
+++ b/.github/workflows/dockerhub-update-description.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: sakowicz/actual-ai
+          repository: fatbob01/actual-ai
           short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/release-build-docker.yml
+++ b/.github/workflows/release-build-docker.yml
@@ -27,4 +27,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: sakowicz/actual-ai:latest,sakowicz/actual-ai:${{ github.ref_name }}
+          tags: fatbob01/actual-ai:latest,fatbob01/actual-ai:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
 
   actual-ai:
-    image: docker.io/sakowicz/actual-ai:latest
+    image: docker.io/fatbob01/actual-ai:latest
     restart: unless-stopped
     depends_on:
       actual_server:

--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,24 @@
 import cron from 'node-cron';
 import { cronSchedule, isFeatureEnabled } from './src/config';
-import actualAi from './src/container';
+import actualAi, { actualApiService } from './src/container';
+
+// Node does not run pending finally/cleanup code for an unhandled SIGTERM/SIGINT — the
+// process just dies, which is exactly how `docker restart`/`docker stop` was leaving the
+// dataDir lock file behind and blocking every subsequent run. Release it explicitly here.
+let isShuttingDown = false;
+function shutdown(signal: string) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  console.log(`Received ${signal}, releasing dataDir lock and exiting`);
+  try {
+    actualApiService.releaseLock();
+  } catch (error) {
+    console.error('Error releasing dataDir lock during shutdown:', error);
+  }
+  process.exit(0);
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
 
 if (!isFeatureEnabled('classifyOnStartup') && !cron.validate(cronSchedule)) {
   console.error('classifyOnStartup not set or invalid cron schedule:', cronSchedule);

--- a/src/actual-ai.ts
+++ b/src/actual-ai.ts
@@ -75,15 +75,33 @@ class ActualAiService implements ActualAiServiceI {
 
   async syncAccounts(): Promise<void> {
     console.log('Syncing bank accounts');
-    try {
-      await suppressConsoleLogsAsync(async () => this.actualApiService.runBankSync());
-      console.log('Bank accounts synced');
-    } catch (error) {
-      console.error(
-        'Error syncing bank accounts:',
-        formatError(error),
-      );
+    const accounts = await this.actualApiService.getAccounts();
+    const syncableAccounts = accounts.filter((account) => !account.closed);
+
+    let succeeded = 0;
+    let failed = 0;
+    // Sync each account independently so that one account needing attention
+    // (e.g. a stale SimpleFin connection) doesn't prevent the others from syncing.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const account of syncableAccounts) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await suppressConsoleLogsAsync(
+          async () => this.actualApiService.runBankSync(account.id),
+        );
+        succeeded += 1;
+      } catch (error) {
+        failed += 1;
+        console.error(
+          `Error syncing bank account "${account.name}":`,
+          formatError(error),
+        );
+      }
     }
+    console.log(
+      `Bank accounts synced: ${succeeded} succeeded, ${failed} failed `
+      + `(${syncableAccounts.length} total)`,
+    );
   }
 
   private isRateLimitError(error: unknown): boolean {

--- a/src/actual-api-service.ts
+++ b/src/actual-api-service.ts
@@ -33,6 +33,11 @@ class ActualApiService implements ActualApiServiceI {
 
   private readonly lockPath: string;
 
+  // A real classify() run should never legitimately take this long. Used as a fallback
+  // for reclaiming a lock whose owning pid appears "alive" only because container
+  // restarts reset the pid counter and something else now holds that same pid.
+  private static readonly MAX_LOCK_AGE_MS = 6 * 60 * 60 * 1000;
+
   constructor(
     actualApiClient: typeof import('@actual-app/api'),
     fs: typeof import('fs'),
@@ -54,50 +59,102 @@ class ActualApiService implements ActualApiServiceI {
     this.lockPath = path.join(this.dataDir, '.actual-ai.lock');
   }
 
+  private static isConcurrentRunError(error: unknown): boolean {
+    return error instanceof Error
+      && error.message.startsWith('Another actual-ai run appears active');
+  }
+
+  private reclaimStaleLockIfAny(): void {
+    const raw = this.fs.readFileSync(this.lockPath, 'utf8');
+    let parsed: { pid?: number; startedAt?: string } | undefined;
+    try {
+      parsed = JSON.parse(raw) as { pid?: number; startedAt?: string };
+    } catch {
+      parsed = undefined;
+    }
+
+    const pid = parsed?.pid;
+    if (typeof pid !== 'number') {
+      // Unparseable/stale lock; remove it.
+      this.fs.unlinkSync(this.lockPath);
+      return;
+    }
+
+    const startedAtMs = parsed?.startedAt ? Date.parse(parsed.startedAt) : NaN;
+    const isTooOld = Number.isFinite(startedAtMs)
+      && Date.now() - startedAtMs > ActualApiService.MAX_LOCK_AGE_MS;
+
+    try {
+      process.kill(pid, 0);
+
+      if (isTooOld) {
+        // The pid looks "alive", but container restarts reset pid counters, so an
+        // unrelated process may have been assigned the same pid. A lock this old is
+        // never legitimate, so reclaim it rather than blocking forever.
+        console.warn(
+          `dataDir lock at ${this.lockPath} is held by pid=${pid} but is older than `
+          + `${ActualApiService.MAX_LOCK_AGE_MS / 3_600_000}h. Assuming it is stale `
+          + '(likely leftover from a container restart that reused this pid) and reclaiming it.',
+        );
+        this.fs.unlinkSync(this.lockPath);
+        return;
+      }
+
+      throw new Error(
+        `Another actual-ai run appears active (pid=${pid}). `
+        + `Refusing to use shared dataDir: ${this.dataDir}`,
+      );
+    } catch (error: unknown) {
+      if (isErrnoException(error) && error.code === 'ESRCH') {
+        // Stale lock from a crashed process; remove it.
+        this.fs.unlinkSync(this.lockPath);
+      } else if (error instanceof Error) {
+        // Either process.kill threw something other than ESRCH, or this is the
+        // "still active" error thrown above; either way, propagate it.
+        throw error;
+      }
+    }
+  }
+
   private acquireDataDirLock() {
     // Prevent multiple concurrent runs from sharing the same dataDir. The underlying
     // Actual sqlite DB is not safe for concurrent writers and can end up "out-of-sync".
-    if (!this.fs.existsSync(this.dataDir)) {
-      this.fs.mkdirSync(this.dataDir, { recursive: true });
-    }
-
-    if (this.fs.existsSync(this.lockPath)) {
-      try {
-        const raw = this.fs.readFileSync(this.lockPath, 'utf8');
-        const parsed = JSON.parse(raw) as { pid?: number; startedAt?: string };
-        const pid = parsed?.pid;
-        if (typeof pid === 'number') {
-          try {
-            process.kill(pid, 0);
-            throw new Error(
-              `Another actual-ai run appears active (pid=${pid}). `
-              + `Refusing to use shared dataDir: ${this.dataDir}`,
-            );
-          } catch (error: unknown) {
-            if (isErrnoException(error) && error.code === 'ESRCH') {
-              // Stale lock from a crashed process; remove it.
-              this.fs.unlinkSync(this.lockPath);
-            } else if (error instanceof Error) {
-              // process.kill threw, but it's not ESRCH; rethrow.
-              throw error;
-            }
-          }
-        } else {
-          // Unparseable/stale lock; remove it.
-          this.fs.unlinkSync(this.lockPath);
-        }
-      } catch (e) {
-        // If anything goes wrong reading the lock, fail safe.
-        throw e instanceof Error ? e : new Error('Failed to read dataDir lock');
+    try {
+      if (!this.fs.existsSync(this.dataDir)) {
+        this.fs.mkdirSync(this.dataDir, { recursive: true });
       }
-    }
 
-    // 'wx' creates exclusively; throws if exists.
-    this.lockFd = this.fs.openSync(this.lockPath, 'wx');
-    this.fs.writeFileSync(
-      this.lockFd,
-      JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }),
-    );
+      if (this.fs.existsSync(this.lockPath)) {
+        this.reclaimStaleLockIfAny();
+      }
+
+      // 'wx' creates exclusively; throws if exists.
+      this.lockFd = this.fs.openSync(this.lockPath, 'wx');
+      this.fs.writeFileSync(
+        this.lockFd,
+        JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }),
+      );
+    } catch (error) {
+      if (ActualApiService.isConcurrentRunError(error)) {
+        throw error;
+      }
+
+      if (isErrnoException(error) && (error.code === 'EACCES' || error.code === 'EPERM')) {
+        // Not a concurrency signal — the environment (e.g. a misconfigured tmpfs mount)
+        // won't let us write the lock at all. Don't block classification over it; just
+        // lose the concurrent-run protection and say why.
+        console.warn(
+          `Could not acquire dataDir lock at ${this.lockPath} (${error.code}: permission denied). `
+          + 'Continuing without the lock, so concurrent runs sharing this dataDir will not be '
+          + `detected. Check that the container user can write to ${this.dataDir} `
+          + '(e.g. drop any custom tmpfs mount on that path, or grant it write access).',
+        );
+        this.lockFd = null;
+        return;
+      }
+
+      throw error instanceof Error ? error : new Error('Failed to acquire dataDir lock');
+    }
   }
 
   private releaseDataDirLock() {
@@ -112,6 +169,13 @@ class ActualApiService implements ActualApiServiceI {
     } catch {
       // Best-effort cleanup.
     }
+  }
+
+  // Public, synchronous, best-effort. Intended for use from process signal handlers
+  // (e.g. SIGTERM on `docker restart`) where we can't rely on in-flight async work
+  // running its normal finally/shutdown path before the process exits.
+  public releaseLock(): void {
+    this.releaseDataDirLock();
   }
 
   public async initializeApi() {
@@ -222,12 +286,12 @@ class ActualApiService implements ActualApiServiceI {
     await this.actualApiClient.updateTransaction(id, { notes, category: categoryId });
   }
 
-  public async runBankSync(): Promise<void> {
+  public async runBankSync(accountId?: string): Promise<void> {
     if (this.isDryRun) {
-      console.log('DRY RUN: Would run bank sync');
+      console.log(`DRY RUN: Would run bank sync${accountId ? ` for account ${accountId}` : ''}`);
       return;
     }
-    await this.actualApiClient.runBankSync();
+    await this.actualApiClient.runBankSync(accountId ? { accountId } : undefined);
   }
 
   public async createCategory(name: string, groupId: string): Promise<string> {

--- a/src/actual-api-service.ts
+++ b/src/actual-api-service.ts
@@ -59,11 +59,22 @@ class ActualApiService implements ActualApiServiceI {
     this.lockPath = path.join(this.dataDir, '.actual-ai.lock');
   }
 
-  private static isConcurrentRunError(error: unknown): boolean {
-    return error instanceof Error
-      && error.message.startsWith('Another actual-ai run appears active');
+  // A signal-0 probe throws ESRCH if the pid doesn't exist, EPERM if it exists but is
+  // owned by another user, or nothing if it exists and we're allowed to signal it — the
+  // latter two both mean "alive" here. Anything other than ESRCH is treated as "alive"
+  // too: wrongly reclaiming a lock that's genuinely still in use (silent dataDir
+  // corruption) is worse than wrongly refusing to reclaim a dead one (a clear error).
+  private static isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error: unknown) {
+      return !(isErrnoException(error) && error.code === 'ESRCH');
+    }
   }
 
+  // Throws if the existing lock is still legitimately held. This is a real concurrency
+  // signal and must never be treated as "can't write the lock file" by the caller.
   private reclaimStaleLockIfAny(): void {
     const raw = this.fs.readFileSync(this.lockPath, 'utf8');
     let parsed: { pid?: number; startedAt?: string } | undefined;
@@ -80,40 +91,51 @@ class ActualApiService implements ActualApiServiceI {
       return;
     }
 
+    if (!ActualApiService.isPidAlive(pid)) {
+      // Stale lock from a crashed process; remove it.
+      this.fs.unlinkSync(this.lockPath);
+      return;
+    }
+
     const startedAtMs = parsed?.startedAt ? Date.parse(parsed.startedAt) : NaN;
     const isTooOld = Number.isFinite(startedAtMs)
       && Date.now() - startedAtMs > ActualApiService.MAX_LOCK_AGE_MS;
 
-    try {
-      process.kill(pid, 0);
-
-      if (isTooOld) {
-        // The pid looks "alive", but container restarts reset pid counters, so an
-        // unrelated process may have been assigned the same pid. A lock this old is
-        // never legitimate, so reclaim it rather than blocking forever.
-        console.warn(
-          `dataDir lock at ${this.lockPath} is held by pid=${pid} but is older than `
-          + `${ActualApiService.MAX_LOCK_AGE_MS / 3_600_000}h. Assuming it is stale `
-          + '(likely leftover from a container restart that reused this pid) and reclaiming it.',
-        );
-        this.fs.unlinkSync(this.lockPath);
-        return;
-      }
-
-      throw new Error(
-        `Another actual-ai run appears active (pid=${pid}). `
-        + `Refusing to use shared dataDir: ${this.dataDir}`,
+    if (isTooOld) {
+      // The pid looks "alive", but container restarts reset pid counters, so an
+      // unrelated process may have been assigned the same pid. A lock this old is
+      // never legitimate, so reclaim it rather than blocking forever.
+      console.warn(
+        `dataDir lock at ${this.lockPath} is held by pid=${pid} but is older than `
+        + `${ActualApiService.MAX_LOCK_AGE_MS / 3_600_000}h. Assuming it is stale `
+        + '(likely leftover from a container restart that reused this pid) and reclaiming it.',
       );
-    } catch (error: unknown) {
-      if (isErrnoException(error) && error.code === 'ESRCH') {
-        // Stale lock from a crashed process; remove it.
-        this.fs.unlinkSync(this.lockPath);
-      } else if (error instanceof Error) {
-        // Either process.kill threw something other than ESRCH, or this is the
-        // "still active" error thrown above; either way, propagate it.
-        throw error;
-      }
+      this.fs.unlinkSync(this.lockPath);
+      return;
     }
+
+    throw new Error(
+      `Another actual-ai run appears active (pid=${pid}). `
+      + `Refusing to use shared dataDir: ${this.dataDir}`,
+    );
+  }
+
+  private failOpenOnPermissionError(error: unknown): boolean {
+    if (!isErrnoException(error) || (error.code !== 'EACCES' && error.code !== 'EPERM')) {
+      return false;
+    }
+
+    // Not a concurrency signal — the environment (e.g. a misconfigured tmpfs mount)
+    // won't let us write the lock at all. Don't block classification over it; just
+    // lose the concurrent-run protection and say why.
+    console.warn(
+      `Could not acquire dataDir lock at ${this.lockPath} (${error.code}: permission denied). `
+      + 'Continuing without the lock, so concurrent runs sharing this dataDir will not be '
+      + `detected. Check that the container user can write to ${this.dataDir} `
+      + '(e.g. drop any custom tmpfs mount on that path, or grant it write access).',
+    );
+    this.lockFd = null;
+    return true;
   }
 
   private acquireDataDirLock() {
@@ -123,11 +145,19 @@ class ActualApiService implements ActualApiServiceI {
       if (!this.fs.existsSync(this.dataDir)) {
         this.fs.mkdirSync(this.dataDir, { recursive: true });
       }
+    } catch (error) {
+      if (this.failOpenOnPermissionError(error)) return;
+      throw error instanceof Error ? error : new Error('Failed to create dataDir');
+    }
 
-      if (this.fs.existsSync(this.lockPath)) {
-        this.reclaimStaleLockIfAny();
-      }
+    if (this.fs.existsSync(this.lockPath)) {
+      // Deliberately outside the try/catch below: an error here (including the
+      // "still active" throw, or a probe failure) is a real concurrency signal, not
+      // an "environment can't write the lock file" situation, and must propagate.
+      this.reclaimStaleLockIfAny();
+    }
 
+    try {
       // 'wx' creates exclusively; throws if exists.
       this.lockFd = this.fs.openSync(this.lockPath, 'wx');
       this.fs.writeFileSync(
@@ -135,35 +165,25 @@ class ActualApiService implements ActualApiServiceI {
         JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }),
       );
     } catch (error) {
-      if (ActualApiService.isConcurrentRunError(error)) {
-        throw error;
-      }
-
-      if (isErrnoException(error) && (error.code === 'EACCES' || error.code === 'EPERM')) {
-        // Not a concurrency signal — the environment (e.g. a misconfigured tmpfs mount)
-        // won't let us write the lock at all. Don't block classification over it; just
-        // lose the concurrent-run protection and say why.
-        console.warn(
-          `Could not acquire dataDir lock at ${this.lockPath} (${error.code}: permission denied). `
-          + 'Continuing without the lock, so concurrent runs sharing this dataDir will not be '
-          + `detected. Check that the container user can write to ${this.dataDir} `
-          + '(e.g. drop any custom tmpfs mount on that path, or grant it write access).',
-        );
-        this.lockFd = null;
-        return;
-      }
-
+      if (this.failOpenOnPermissionError(error)) return;
       throw error instanceof Error ? error : new Error('Failed to acquire dataDir lock');
     }
   }
 
   private releaseDataDirLock() {
+    // Only ever unlink a lock this instance actually opened. Without this check, a
+    // process that never held the lock (e.g. one that lost dataDir contention to
+    // another process legitimately sharing the same volume) could delete that other
+    // process's still-valid lock — most easily reached via releaseLock() below, which
+    // a signal handler can call at any time regardless of whether this instance is
+    // mid-run or ever acquired the lock in the first place.
+    const heldLock = this.lockFd !== null;
     try {
       if (this.lockFd !== null) {
         this.fs.closeSync(this.lockFd);
         this.lockFd = null;
       }
-      if (this.fs.existsSync(this.lockPath)) {
+      if (heldLock && this.fs.existsSync(this.lockPath)) {
         this.fs.unlinkSync(this.lockPath);
       }
     } catch {

--- a/src/container.ts
+++ b/src/container.ts
@@ -90,7 +90,7 @@ const llmModelFactory = new LlmModelFactory(
   groqBaseURL,
 );
 
-const actualApiService = new ActualApiService(
+export const actualApiService = new ActualApiService(
   actualApiClient,
   fs,
   dataDir,

--- a/src/prompt-generator.ts
+++ b/src/prompt-generator.ts
@@ -5,7 +5,7 @@ import {
   PromptGeneratorI,
 } from './types';
 import PromptTemplateException from './exceptions/prompt-template-exception';
-import { isToolEnabled } from './config';
+import { isFeatureEnabled, isToolEnabled } from './config';
 import { transformRulesToDescriptions } from './utils/rule-utils';
 
 class PromptGenerator implements PromptGeneratorI {
@@ -60,6 +60,7 @@ class PromptGenerator implements PromptGeneratorI {
         cleared: transaction.cleared,
         reconciled: transaction.reconciled,
         hasWebSearchTool: webSearchEnabled,
+        allowNewCategories: isFeatureEnabled('suggestNewCategories'),
       });
     } catch {
       console.error('Error generating prompt. Check syntax of your template.');

--- a/src/templates/prompt.hbs
+++ b/src/templates/prompt.hbs
@@ -33,17 +33,23 @@ Existing Rules:
 
 IMPORTANT: You MUST respond with ONLY a valid JSON object using this structure:
 {
-  "type": "existing"|"new"|"rule",
+  "type": "existing"|"rule"{{#if allowNewCategories}}|"new"{{/if}},
   "categoryId": "string", // Required for "existing"; for "rule" include only when the matched rule sets a category, omit when the rule says "leave uncategorized"
-  "ruleName": "string", // Required if matching rule
-  "newCategory": { // Required if suggesting new category
+  "ruleName": "string" // Required if matching rule
+{{#if allowNewCategories}}
+  ,"newCategory": { // Required if suggesting new category
     "name": "string",
     "groupName": "string",
     "groupIsNew": boolean
   }
+{{/if}}
 }
 
-If a rule renders as "→ leave uncategorized", that rule explicitly tells you NOT to assign a category. Match it with type "rule" and the ruleName, and OMIT categoryId — do not invent one and do not fall back to "new".
+If a rule renders as "→ leave uncategorized", that rule explicitly tells you NOT to assign a category. Match it with type "rule" and the ruleName, and OMIT categoryId — do not invent one{{#if allowNewCategories}} and do not fall back to "new"{{/if}}.
+
+{{#unless allowNewCategories}}
+Only use categories that already exist above — do not invent a new one. If nothing fits, use the closest existing category.
+{{/unless}}
 
 DO NOT output any text before or after the JSON. Your entire response must be a valid, parsable JSON object.
 
@@ -51,7 +57,9 @@ Examples:
 {"type": "existing", "categoryId": "abc123"}
 {"type": "rule", "categoryId": "def456", "ruleName": "Coffee Shop"}
 {"type": "rule", "ruleName": "Amazon leave uncategorized"}
+{{#if allowNewCategories}}
 {"type": "new", "newCategory": {"name": "Pet Supplies", "groupName": "Pets", "groupIsNew": true}}
+{{/if}}
 
 {{#if hasWebSearchTool}}
 You can use the web search tool to find more information about the transaction.

--- a/src/transaction/processing-strategy/new-category-strategy.ts
+++ b/src/transaction/processing-strategy/new-category-strategy.ts
@@ -2,10 +2,21 @@ import { CategoryEntity, TransactionEntity } from '@actual-app/core/src/types/mo
 import type {
   ProcessingStrategyI, UnifiedResponse,
 } from '../../types';
+import { isFeatureEnabled } from '../../config';
 
 class NewCategoryStrategy implements ProcessingStrategyI {
   public isSatisfiedBy(response: UnifiedResponse): boolean {
     if (response.newCategory === undefined) {
+      return false;
+    }
+    if (!isFeatureEnabled('suggestNewCategories')) {
+      // The prompt is only supposed to offer "new" when this feature is on, but LLMs
+      // don't always follow instructions. Claiming this response here when the feature
+      // is off would silently drop it: CategorySuggester.suggest() (which actually
+      // creates the category and updates the transaction) is gated on the same flag in
+      // TransactionService, so nothing would ever act on it. Reject it instead so the
+      // transaction falls through to the "unexpected response" handling and gets
+      // tagged not-guessed rather than silently retried forever.
       return false;
     }
     return response.type === 'new';

--- a/src/transaction/tag-service.ts
+++ b/src/transaction/tag-service.ts
@@ -28,14 +28,19 @@ class TagService {
   }
 
   public clearPreviousTags(notes: string): string {
+    // The "-miss" repair must run while the " #actual-ai" anchor still exists,
+    // and the longer tag must be cleared before the shorter one: the default
+    // guessedTag "#actual-ai" is a prefix of notGuessedTag "#actual-ai-miss",
+    // so clearing it first ate the tag's head and glued one stray "-miss" onto
+    // the note body per rerun ("…-miss-miss #actual-ai-miss").
     return notes
-      .replace(new RegExp(`\\s*${this.guessedTag}`, 'g'), '')
+      .replace(/(-miss)+(?= #actual-ai)/g, '')
       .replace(new RegExp(`\\s*${this.notGuessedTag}`, 'g'), '')
+      .replace(new RegExp(`\\s*${this.guessedTag}`, 'g'), '')
       .replace(new RegExp(`\\s*\\|\\s*${LEGACY_NOTES_NOT_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*\\|\\s*${LEGACY_NOTES_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*${LEGACY_NOTES_GUESSED}`, 'g'), '')
       .replace(new RegExp(`\\s*${LEGACY_NOTES_NOT_GUESSED}`, 'g'), '')
-      .replace(/-miss(?= #actual-ai)/g, '')
       .trim();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,9 @@ export interface ActualApiServiceI {
     categoryId: string,
   ): Promise<void>
 
-  runBankSync(): Promise<void>
+  runBankSync(accountId?: string): Promise<void>
+
+  releaseLock(): void
 
   createCategory(name: string, groupId: string): Promise<string>
 

--- a/src/utils/free-web-search-service.ts
+++ b/src/utils/free-web-search-service.ts
@@ -64,7 +64,7 @@ export default class FreeWebSearchService {
       const attempt = () => {
         https.get(url, {
           headers: {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36',
             Accept: 'text/html,application/xhtml+xml,application/xml',
             'Accept-Language': 'en-US,en;q=0.9',
           },

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -23,6 +23,32 @@ function cleanJsonResponse(text: string): string {
   return cleaned.trim();
 }
 
+// Models sometimes prepend prose reasoning to the JSON object — and when the
+// prompt contains bracketed note tags like "[enricher]", the prose echoes them,
+// so cleanJsonResponse's "first structure character" cut lands inside the prose
+// instead of the JSON. Recover by scanning for the last balanced {...} block
+// that parses. Braces inside JSON strings can break the depth count; then the
+// parse fails and the scan moves on to an earlier candidate.
+function extractLastJsonObject(text: string): Partial<UnifiedResponse> | null {
+  for (let start = text.lastIndexOf('{'); start !== -1; start = text.lastIndexOf('{', start - 1)) {
+    let depth = 0;
+    for (let i = start; i < text.length; i += 1) {
+      if (text[i] === '{') depth += 1;
+      if (text[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          try {
+            return JSON.parse(text.slice(start, i + 1)) as Partial<UnifiedResponse>;
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
 function parseLlmResponse(text: string): UnifiedResponse {
   const cleanedText = cleanJsonResponse(text);
   console.log('Cleaned LLM response:', cleanedText);
@@ -43,7 +69,12 @@ function parseLlmResponse(text: string): UnifiedResponse {
         };
       }
 
-      throw new Error('Response is neither valid JSON nor simple ID');
+      const extracted = extractLastJsonObject(text);
+      if (extracted === null) {
+        throw new Error('Response is neither valid JSON nor simple ID');
+      }
+      console.log('Recovered trailing JSON object from prose LLM response');
+      parsed = extracted;
     }
 
     if (parsed.type === 'existing' && parsed.categoryId) {

--- a/tests/actual-ai.test.ts
+++ b/tests/actual-ai.test.ts
@@ -442,6 +442,29 @@ describe('ActualAiService', () => {
     expect(inMemoryApiService.getWasBankSyncRan()).toBe(true);
   });
 
+  it('It should sync remaining accounts when one account fails to sync', async () => {
+    // Arrange
+    mockIsFeatureEnabled.mockImplementation((feature: string) => {
+      if (feature === 'syncAccountsBeforeClassify') return true;
+      if (feature === 'rerunMissedTransactions') return false;
+      return originalIsFeatureEnabled(feature);
+    });
+    inMemoryApiService.setAccountIdsThatFailToSync([GivenActualData.ACCOUNT_MAIN]);
+
+    // Act
+    sut = new ActualAiService(
+      transactionService,
+      inMemoryApiService,
+      notesMigrator,
+    );
+    await sut.classify();
+
+    // Assert: both accounts were attempted individually, despite one failing
+    expect(inMemoryApiService.getBankSyncAccountIds()).toEqual(
+      expect.arrayContaining([GivenActualData.ACCOUNT_MAIN, GivenActualData.ACCOUNT_OFF_BUDGET]),
+    );
+  });
+
   // Add a new test for when rerunMissedTransactions is true
   it('It should process transaction with missed tag when rerunMissedTransactions is true', async () => {
     // Arrange

--- a/tests/data-dir-lock.test.ts
+++ b/tests/data-dir-lock.test.ts
@@ -7,50 +7,47 @@ function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'actual-ai-lock-test-'));
 }
 
+function makeClient(): typeof import('@actual-app/api') {
+  const asyncNoop = jest.fn(async () => Promise.resolve());
+  return {
+    init: asyncNoop,
+    downloadBudget: asyncNoop,
+    shutdown: asyncNoop,
+    getCategoryGroups: jest.fn(),
+    getCategories: jest.fn(),
+    getPayees: jest.fn(),
+    getAccounts: jest.fn(),
+    getTransactions: jest.fn(),
+    getRules: jest.fn(),
+    getPayeeRules: jest.fn(),
+    createRule: jest.fn(),
+    updateTransaction: jest.fn(),
+    runBankSync: jest.fn(),
+    createCategory: jest.fn(),
+    createCategoryGroup: jest.fn(),
+    updateCategoryGroup: jest.fn(),
+  } as unknown as typeof import('@actual-app/api');
+}
+
+function makeService(dataDir: string): ActualApiService {
+  return new ActualApiService(
+    makeClient(),
+    fs,
+    dataDir,
+    'http://example.com',
+    'pw',
+    'budget',
+    '',
+    true,
+  );
+}
+
 describe('ActualApiService dataDir lock', () => {
   test('prevents concurrent runs from sharing the same dataDir', async () => {
     const dataDir = makeTmpDir();
 
-    const asyncNoop = jest.fn(async () => Promise.resolve());
-    const client = {
-      init: asyncNoop,
-      downloadBudget: asyncNoop,
-      shutdown: asyncNoop,
-      getCategoryGroups: jest.fn(),
-      getCategories: jest.fn(),
-      getPayees: jest.fn(),
-      getAccounts: jest.fn(),
-      getTransactions: jest.fn(),
-      getRules: jest.fn(),
-      getPayeeRules: jest.fn(),
-      createRule: jest.fn(),
-      updateTransaction: jest.fn(),
-      runBankSync: jest.fn(),
-      createCategory: jest.fn(),
-      createCategoryGroup: jest.fn(),
-      updateCategoryGroup: jest.fn(),
-    } as unknown as typeof import('@actual-app/api');
-
-    const s1 = new ActualApiService(
-      client,
-      fs,
-      dataDir,
-      'http://example.com',
-      'pw',
-      'budget',
-      '',
-      true,
-    );
-    const s2 = new ActualApiService(
-      client,
-      fs,
-      dataDir,
-      'http://example.com',
-      'pw',
-      'budget',
-      '',
-      true,
-    );
+    const s1 = makeService(dataDir);
+    const s2 = makeService(dataDir);
 
     await s1.initializeApi();
 
@@ -61,5 +58,47 @@ describe('ActualApiService dataDir lock', () => {
     // After the first run releases the lock, the second should be able to initialize.
     await expect(s2.initializeApi()).resolves.toBeUndefined();
     await s2.shutdownApi();
+  });
+
+  test('treats EPERM from a live pid probe as "still active", not as a permission failure', async () => {
+    const dataDir = makeTmpDir();
+    const lockPath = path.join(dataDir, '.actual-ai.lock');
+    fs.writeFileSync(
+      lockPath,
+      JSON.stringify({ pid: 999999, startedAt: new Date().toISOString() }),
+    );
+
+    // Simulate probing a pid that exists but is owned by another user: process.kill
+    // throws EPERM, not ESRCH. That must still be read as "alive", not silently
+    // downgraded to "can't write the lock file, proceed without it".
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('Operation not permitted'), { code: 'EPERM' });
+    });
+
+    try {
+      const service = makeService(dataDir);
+      await expect(service.initializeApi()).rejects.toThrow(/Refusing to use shared dataDir/i);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  test('releaseLock() does not delete a lock this instance never held', async () => {
+    const dataDir = makeTmpDir();
+    const lockPath = path.join(dataDir, '.actual-ai.lock');
+
+    const s1 = makeService(dataDir);
+    const s2 = makeService(dataDir);
+
+    await s1.initializeApi();
+    await expect(s2.initializeApi()).rejects.toThrow(/Refusing to use shared dataDir/i);
+
+    // s2 never acquired the lock; releasing it (e.g. from a SIGTERM handler) must not
+    // delete s1's still-active lock.
+    s2.releaseLock();
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    await s1.shutdownApi();
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 });

--- a/tests/json-utils.test.ts
+++ b/tests/json-utils.test.ts
@@ -37,4 +37,31 @@ describe('parseLlmResponse', () => {
     expect(result.type).toBe('new');
     expect(result.newCategory).toEqual({ name: 'Pets', groupName: 'Home', groupIsNew: true });
   });
+
+  it('parses a fenced JSON response', () => {
+    expect(parseLlmResponse('```json\n{"type": "existing", "categoryId": "abc"}\n```'))
+      .toEqual({ type: 'existing', categoryId: 'abc' });
+  });
+
+  it('parses a bare category id', () => {
+    expect(parseLlmResponse('3de93c74-04be-4a32-8131-226f1d0efd69'))
+      .toEqual({ type: 'existing', categoryId: '3de93c74-04be-4a32-8131-226f1d0efd69' });
+  });
+
+  // Regression: prose reasoning that echoes bracketed note tags ("[enricher]…")
+  // made the first-structure-character cut land in the prose, discarding the
+  // valid JSON object at the end of the response.
+  it('recovers the trailing JSON object from a prose response', () => {
+    const prose = 'The `[enricher]` note from the email receipt identifies the item as: '
+      + '**"WUBEN G5 LED Taschenlampe"** — a tech gadget purchased on Amazon.\n'
+      + '- The amount matches (23.98 EUR)\n\n'
+      + '{"type": "existing", "categoryId": "3de93c74-04be-4a32-8131-226f1d0efd69"}';
+    expect(parseLlmResponse(prose))
+      .toEqual({ type: 'existing', categoryId: '3de93c74-04be-4a32-8131-226f1d0efd69' });
+  });
+
+  it('still rejects a response with no JSON object at all', () => {
+    expect(() => parseLlmResponse('I cannot categorize this [enricher] transaction.'))
+      .toThrow('Invalid response format from LLM');
+  });
 });

--- a/tests/new-category-strategy.test.ts
+++ b/tests/new-category-strategy.test.ts
@@ -1,0 +1,78 @@
+import NewCategoryStrategy from '../src/transaction/processing-strategy/new-category-strategy';
+import GivenActualData from './test-doubles/given/given-actual-data';
+import * as config from '../src/config';
+
+describe('NewCategoryStrategy', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isSatisfiedBy', () => {
+    it('matches a "new" response with newCategory when suggestNewCategories is enabled', () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(true);
+      const strategy = new NewCategoryStrategy();
+
+      expect(strategy.isSatisfiedBy({
+        type: 'new',
+        newCategory: { name: 'Pet Supplies', groupName: 'Pets', groupIsNew: true },
+      })).toBe(true);
+    });
+
+    it('rejects a "new" response when suggestNewCategories is disabled, even though the LLM sent one', () => {
+      // The prompt is only supposed to offer "new" when the feature is on, but the LLM
+      // doesn't always follow instructions. If this strategy claimed the response
+      // anyway, CategorySuggester.suggest() (gated on the same flag) would never act on
+      // it, silently dropping the transaction instead of falling through to the
+      // not-guessed path.
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(false);
+      const strategy = new NewCategoryStrategy();
+
+      expect(strategy.isSatisfiedBy({
+        type: 'new',
+        newCategory: { name: 'Pet Supplies', groupName: 'Pets', groupIsNew: true },
+      })).toBe(false);
+    });
+
+    it('rejects a response without newCategory regardless of the feature flag', () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(true);
+      const strategy = new NewCategoryStrategy();
+
+      expect(strategy.isSatisfiedBy({ type: 'new' })).toBe(false);
+    });
+
+    it('rejects non-"new" responses even with newCategory present', () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(true);
+      const strategy = new NewCategoryStrategy();
+
+      expect(strategy.isSatisfiedBy({
+        type: 'existing',
+        categoryId: 'cat-1',
+        newCategory: { name: 'Pet Supplies', groupName: 'Pets', groupIsNew: true },
+      })).toBe(false);
+    });
+  });
+
+  describe('process', () => {
+    it('buffers the transaction under a key combining group and category name', async () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(true);
+      const strategy = new NewCategoryStrategy();
+      const suggestedCategories = new Map<string, {
+        name: string;
+        groupName: string;
+        groupIsNew: boolean;
+        groupId?: string;
+        transactions: ReturnType<typeof GivenActualData.createTransaction>[];
+      }>();
+      const transaction = GivenActualData.createTransaction('1', -123, 'Pet Store');
+
+      await strategy.process(
+        transaction,
+        { type: 'new', newCategory: { name: 'Pet Supplies', groupName: 'Pets', groupIsNew: true } },
+        [],
+        suggestedCategories,
+      );
+
+      expect(suggestedCategories.get('Pets:Pet Supplies')?.transactions).toEqual([transaction]);
+    });
+  });
+});

--- a/tests/prompt-generator.test.ts
+++ b/tests/prompt-generator.test.ts
@@ -80,6 +80,7 @@ describe('PromptGenerator', () => {
       cleared: transaction.cleared ?? false,
       reconciled: transaction.reconciled ?? false,
       hasWebSearchTool: false,
+      allowNewCategories: false,
       rules: [],
     });
   };
@@ -165,6 +166,40 @@ ANSWER BY A CATEGORY ID - DO NOT CREATE ENTIRE SENTENCE - DO NOT WRITE CATEGORY 
     expect(prompt).toContain('* Amount: 1000');
     expect(prompt).toContain('* Type: Outcome');
     expect(prompt).toContain('* Date: 2021-01-01');
+  });
+
+  describe('suggestNewCategories gating', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('does not offer the "new" category type when suggestNewCategories is disabled', () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(false);
+
+      const transaction = GivenActualData.createTransaction('1', -1000, 'Carrefour 2137');
+      const categoryGroups = GivenActualData.createSampleCategoryGroups();
+      const payees = GivenActualData.createSamplePayees();
+
+      const promptGenerator = new PromptGenerator(promptTemplate);
+      const prompt = promptGenerator.generate(categoryGroups, transaction, payees, []);
+
+      expect(prompt).not.toContain('"new"');
+      expect(prompt).not.toContain('newCategory');
+    });
+
+    it('offers the "new" category type when suggestNewCategories is enabled', () => {
+      jest.spyOn(config, 'isFeatureEnabled').mockReturnValue(true);
+
+      const transaction = GivenActualData.createTransaction('1', -1000, 'Carrefour 2137');
+      const categoryGroups = GivenActualData.createSampleCategoryGroups();
+      const payees = GivenActualData.createSamplePayees();
+
+      const promptGenerator = new PromptGenerator(promptTemplate);
+      const prompt = promptGenerator.generate(categoryGroups, transaction, payees, []);
+
+      expect(prompt).toContain('"new"');
+      expect(prompt).toContain('newCategory');
+    });
   });
 
   describe('web search tool', () => {

--- a/tests/tag-service.test.ts
+++ b/tests/tag-service.test.ts
@@ -1,0 +1,44 @@
+import TagService from '../src/transaction/tag-service';
+
+describe('TagService', () => {
+  const service = new TagService('#actual-ai-miss', '#actual-ai');
+
+  describe('addNotGuessedTag', () => {
+    it('tags an untagged note', () => {
+      expect(service.addNotGuessedTag('some note')).toBe('some note #actual-ai-miss');
+    });
+
+    it('is idempotent on an already-tagged note (regression: "-miss" grew per rerun)', () => {
+      const once = service.addNotGuessedTag('some note');
+      expect(service.addNotGuessedTag(once)).toBe(once);
+    });
+
+    it('heals "-miss" chains left by the prefix-eating bug', () => {
+      expect(service.addNotGuessedTag('some note-miss-miss #actual-ai-miss'))
+        .toBe('some note #actual-ai-miss');
+    });
+  });
+
+  describe('addGuessedTag', () => {
+    it('replaces the miss tag without leaving a stray "-miss" on the note body', () => {
+      expect(service.addGuessedTag('some note #actual-ai-miss')).toBe('some note #actual-ai');
+    });
+
+    it('is idempotent on an already-guessed note', () => {
+      const once = service.addGuessedTag('some note');
+      expect(service.addGuessedTag(once)).toBe(once);
+    });
+  });
+
+  describe('clearPreviousTags', () => {
+    it('removes both tags and healed "-miss" chains', () => {
+      expect(service.clearPreviousTags('some note-miss #actual-ai-miss')).toBe('some note');
+      expect(service.clearPreviousTags('some note #actual-ai')).toBe('some note');
+    });
+
+    it('keeps unrelated note content untouched', () => {
+      const note = '[enrich:gocardless] eBay O*05-13940-83058 (Σ -42.73 EUR)';
+      expect(service.clearPreviousTags(`${note} #actual-ai-miss`)).toBe(note);
+    });
+  });
+});

--- a/tests/test-doubles/in-memory-actual-api-service.ts
+++ b/tests/test-doubles/in-memory-actual-api-service.ts
@@ -20,6 +20,10 @@ export default class InMemoryActualApiService implements ActualApiServiceI {
 
   private wasBankSyncRan = false;
 
+  private bankSyncAccountIds: (string | undefined)[] = [];
+
+  private accountIdsThatFailToSync = new Set<string>();
+
   private rules: RuleEntity[] = [];
 
   private readonly isDryRun: boolean;
@@ -110,13 +114,29 @@ export default class InMemoryActualApiService implements ActualApiServiceI {
     });
   }
 
-  async runBankSync(): Promise<void> {
+  async runBankSync(accountId?: string): Promise<void> {
     this.wasBankSyncRan = true;
+    this.bankSyncAccountIds.push(accountId);
+    if (accountId && this.accountIdsThatFailToSync.has(accountId)) {
+      throw new Error(`Simulated sync failure for account ${accountId}`);
+    }
     return Promise.resolve();
   }
 
   public getWasBankSyncRan(): boolean {
     return this.wasBankSyncRan;
+  }
+
+  public getBankSyncAccountIds(): (string | undefined)[] {
+    return this.bankSyncAccountIds;
+  }
+
+  public setAccountIdsThatFailToSync(accountIds: string[]): void {
+    this.accountIdsThatFailToSync = new Set(accountIds);
+  }
+
+  public releaseLock(): void {
+    // No-op for the in-memory test double.
   }
 
   async createCategory(name: string, groupId: string): Promise<string> {


### PR DESCRIPTION
## Summary

Cherry-picked two unmerged, human-authored bug fixes from upstream (sakowicz/actual-ai), both verified as real and present in this fork's code before picking. Not written by me — full credit to the original author (Sebastian Patino-Lang / perelin), commits picked as-is with authorship preserved.

**1. [sakowicz/actual-ai#438](https://github.com/sakowicz/actual-ai/pull/438) — `clearPreviousTags` grows `-miss` chains on every rerun**

Directly affects this deployment: the default tags (`#actual-ai` / `#actual-ai-miss`) mean the guessed tag is a literal prefix of the not-guessed tag, and `rerunMissedTransactions` is enabled in this stack's `FEATURES`. `clearPreviousTags` cleared the shorter `guessedTag` first, which ate the head of `#actual-ai-miss` and left a stray `-miss` glued to the note body; the existing single-`-miss` repair ran *after* that removal, once its ` #actual-ai` anchor was already gone, so it never fired. Every rerun over a still-missed transaction appended one more `-miss`:

```
some note #actual-ai-miss
→ some note-miss #actual-ai-miss
→ some note-miss-miss #actual-ai-miss
```

Fix: run the (now chain-aware) `-miss` repair first while the anchor still exists, and clear the longer tag before the shorter one. Verified this bug is present byte-for-byte in this fork's `tag-service.ts` before picking.

**2. [sakowicz/actual-ai#439](https://github.com/sakowicz/actual-ai/pull/439) — prose LLM responses discard the trailing JSON object**

`cleanJsonResponse` cuts everything before the first `{`/`[`. When the model prepends prose that itself echoes bracketed content (e.g. transaction notes carrying tags like `[enricher]`), that cut lands inside the prose instead of the real JSON, `JSON.parse` fails, and a transaction the model actually answered correctly gets tagged as a miss instead. Author reports 24/571 transactions failing this way on a live run, 0 after the fix. Fix adds a fallback that scans backward for the last balanced `{...}` block that parses.

## Testing

- `npx jest` — 143/143 passing (adds upstream's `tests/tag-service.test.ts` and extends `tests/json-utils.test.ts`)
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- Both PRs' own descriptions include live-deployment verification (0 failures after deploying, chains healed on rerun) from the original author